### PR TITLE
Add support for key files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target-cross
 config.toml
 *.ca-bundle
+*.key

--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ To run straight from the command line, run
 
 `cycle-certs --domain=<YOUR DOMAIN> --apikey=<API KEY> --hub=<HUB ID>`
 
-This will download the certificate bundle and install it in the current working directory with the name `<YOUR DOMAIN>.ca-bundle`. 
+This will download a certificate bundle and private key associated with the specified domain. By default, the files will be stored in the current working directory with the names:
 
-_Note - If your certificate applies to multiple domains, they will be separated by an underscore. All periods are also replaced with underscores. Therefore, if your domain were e.g. cycle.io, the bundle would be saved to a file `cycle_io.ca-bundle`. If your domains were `cycle.io` and `test.com`, the bundle would be saved to `cycle_io_test_com.ca-bundle`_
+- `<YOUR DOMAIN>.ca-bundle`
+- `<YOUR DOMAIN>.key` 
+
+_Note - If your certificate applies to multiple domains, they will be separated by an underscore. All periods are also replaced with underscores. Therefore, if your domain were e.g. cycle.io, the bundle would be saved to a file `cycle_io.ca-bundle`. If your domains were `cycle.io` and `test.com`, the bundle would be saved to `cycle_io_test_com.ca-bundle`. To avoid this, pass the `--filename` argument._
 
 The process will sleep in the background, until 14 days before the certificate expires, when it will attempt to fetch the latest certificate again. (Cycle renews certificates 65 days after generation).
 

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -66,7 +66,7 @@ pub(crate) struct CycleCert {
     domains: Vec<String>,
     bundle: String,
     events: Events,
-    private_key: String
+    private_key: String,
 }
 
 impl CycleCert {

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -124,12 +124,13 @@ mod tests {
     fn test_writing_bundle() -> anyhow::Result<()> {
         let dir = tempdir()?;
 
-        let content = String::from("CONTENTS OF CERTIFICATE HERE");
+        let bundle = String::from("CONTENTS OF CERTIFICATE HERE");
+        let private_key = String::from("Key to the castle");
 
         let cert = CycleCert {
             domains: vec!["cycle.io".to_string()],
-            bundle: content.clone(),
-            private_key: "Key to the castle".into(),
+            bundle: bundle.clone(),
+            private_key: private_key.clone(),
             events: Events {
                 generated: Utc::now(),
             },
@@ -137,8 +138,11 @@ mod tests {
 
         cert.write_to_disk(dir.path().to_str().unwrap(), None)?;
 
-        let cert_file_content = std::fs::read_to_string(dir.path().join("cycle_io.ca-bundle"))?;
-        assert_eq!(content, cert_file_content);
+        let bundle_file = std::fs::read_to_string(dir.path().join("cycle_io.ca-bundle"))?;
+        assert_eq!(bundle, bundle_file);
+
+        let key_file = std::fs::read_to_string(dir.path().join("cycle_io.key"))?;
+        assert_eq!(private_key, key_file);
 
         Ok(())
     }
@@ -147,12 +151,13 @@ mod tests {
     fn test_writing_bundle_multiple_domains() -> anyhow::Result<()> {
         let dir = tempdir()?;
 
-        let content = String::from("CONTENTS OF CERTIFICATE HERE");
+        let bundle = String::from("CONTENTS OF CERTIFICATE HERE");
+        let private_key = String::from("Key to the castle");
 
         let cert = CycleCert {
             domains: vec!["cycle.io".to_string(), "petrichor.io".to_string()],
-            bundle: content.clone(),
-            private_key: "Key to the castle".into(),
+            bundle: bundle.clone(),
+            private_key: private_key.clone(),
             events: Events {
                 generated: Utc::now(),
             },
@@ -160,9 +165,12 @@ mod tests {
 
         cert.write_to_disk(dir.path().to_str().unwrap(), None)?;
 
-        let cert_file_content =
+        let bundle_file =
             std::fs::read_to_string(dir.path().join("cycle_io_petrichor_io.ca-bundle"))?;
-        assert_eq!(content, cert_file_content);
+        assert_eq!(bundle, bundle_file);
+
+        let key_file = std::fs::read_to_string(dir.path().join("cycle_io_petrichor_io.key"))?;
+        assert_eq!(private_key, key_file);
 
         Ok(())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ impl Config {
                 )
                 .required(false),
             )
-            .set_default("certificate_path", "./")?
+            .set_default("certificate_path", ".")?
             .set_default("refresh_days", 14)?
             .set_default("cluster", "api.cycle.io")?
             // Allow the user to pass these items via CLI params. We validate later.

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,14 +92,20 @@ fn main() -> Result<()> {
         cert.write_to_disk(&config.certificate_path, filename_override)
             .with_context(|| {
                 format!(
-                    "Failed to write certificate to path {}",
-                    cert.get_certificate_full_filepath(&config.certificate_path, filename_override)
+                    "Failed to write files. \nCertificate: {}\nKey: {}",
+                    cert.get_certificate_full_filepath(&config.certificate_path, filename_override),
+                    cert.get_private_key_full_filepath(&config.certificate_path, filename_override)
                 )
             })?;
 
         log::info!(
             "Wrote certificate bundle to {}",
             cert.get_certificate_full_filepath(&config.certificate_path, filename_override)
+        );
+
+        log::info!(
+            "Wrote private key to {}",
+            cert.get_private_key_full_filepath(&config.certificate_path, filename_override)
         );
 
         log::info!("Next fetch in {} days", duration.num_days());


### PR DESCRIPTION
Adds support for downloading and storing the private key associated with a bundle. Waiting on an upstream change in Cycle's public API before merging.